### PR TITLE
Presets

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -27,4 +27,7 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-#     import_config "#{Mix.env}.exs"
+if(Mix.env == :test) do
+  import_config "test.exs"
+end
+

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,5 @@
+use Mix.Config
+
+config :ex_junk,
+  phone: [Integer, [size: 10]],
+  ssn: &JunkTest.ssn/0

--- a/lib/ex_junk.ex
+++ b/lib/ex_junk.ex
@@ -32,6 +32,9 @@ defmodule Junk do
     Range.new(min,max) |> Enum.random
   end
 
+  def junk(regex = %{__struct__: Regex}, opts) do
+  end
+
   defp construct_opts(opts) do
     Enum.into(opts, Map.from_struct(%Junk{}))
   end

--- a/lib/ex_junk.ex
+++ b/lib/ex_junk.ex
@@ -4,49 +4,35 @@ defmodule Junk do
   It is inspired by Dave Brady's [rspec-junklet](https://github.com/dbrady/rspec-junklet)
   """
 
-  @inject %{random_bytes: &:crypto.strong_rand_bytes/1}
-
-  @default_opts [
-    byte_size: 32,
+  defstruct byte_size: 32,
     prefix: "",
-    rand_mod: @inject,
+    rand_mod: &:crypto.strong_rand_bytes/1,
     size: 16
-  ]
 
   @doc """
-  Returns junk(String).
+  Takes a Module (String, Integer) and options, returns junk for that Module.
   """
-  def junk, do: junk(String, @default_opts)
+  def junk(_, opts \\ [])
 
-  @doc """
-  Returns junk(String, opts)
-  """
-  def junk(opts) when is_list(opts) do
+  def junk(opts, _) when is_list(opts) do
     junk(String, opts)
   end
 
-  @doc """
-  Takes a Module (String, Integer), and options, returns junk for that Module.
-  """
-  def junk(junk_type, opts \\ @default_opts) do
-    merged_opts = @default_opts
-    |> Keyword.merge(opts)
-    |> Enum.into(%{})
-    junk_for_type(junk_type, merged_opts)
-  end
-
-  defp junk_for_type(:"Elixir.String", opts) do
-    string = random_bytes(opts)
+  def junk(String, opts) do
+    opts = construct_opts(opts)
+    string = opts.rand_mod.(opts.byte_size)
     |> Base.url_encode64
     opts.prefix <> "-" <> string
   end
-  defp junk_for_type(:"Elixir.Integer", opts) do
+
+  def junk(Integer, opts) do
+    opts = construct_opts(opts)
     min = :math.pow(10, opts.size-1) |> trunc
     max = :math.pow(10, opts.size)-1 |> trunc
     Range.new(min,max) |> Enum.random
   end
 
-  defp random_bytes(%{rand_mod: rand_mod, byte_size: b_size}) do
-    rand_mod.random_bytes.(b_size)
+  defp construct_opts(opts) do
+    Enum.into(opts, Map.from_struct(%Junk{}))
   end
 end

--- a/test/ex_junk_test.exs
+++ b/test/ex_junk_test.exs
@@ -37,4 +37,31 @@ defmodule JunkTest do
     digits = Junk.junk(Integer, size: 25) |> Integer.digits
     assert Kernel.length(digits) == 25
   end
+
+  test "returns a value when a function is used" do
+    foo = Junk.junk(fn() -> "foo" end)
+    assert "foo" = foo
+  end
+
+  test "returns a value when a function is used with a parameter" do
+    f = fn(x) -> "#{x}-result" end
+    output = Junk.junk(f, parameters: [1])
+    assert "1-result" = output
+    output2 = Junk.junk(f, parameters: [2])
+    assert "2-result" = output2
+  end
+
+  test "returns a preset value when a preset is defined and used" do
+    output = Junk.junk(:phone)
+    assert 10 = length(output |> Integer.digits)
+  end
+
+  test "returns a preset value when a preset function is used" do
+    output = Junk.junk(:ssn)
+    assert "123-45-6789" = output
+  end
+
+  def ssn do
+    "123-45-6789"
+  end
 end

--- a/test/ex_junk_test.exs
+++ b/test/ex_junk_test.exs
@@ -2,7 +2,14 @@ defmodule JunkTest do
   use ExUnit.Case
   doctest Junk
 
-  test "no args defaults .junk to String" do
+  test "no parameters whatsoever returns random string" do
+    output = Junk.junk
+    assert is_binary(output) == true
+    assert String.printable?(output) == true
+    assert output != Junk.junk(String)
+  end
+
+  test "no option defaults .junk to String" do
     output = Junk.junk(String)
     assert is_binary(output) == true
     assert String.printable?(output) == true
@@ -28,6 +35,11 @@ defmodule JunkTest do
     assert String.starts_with?(output, "prefix-")
   end
 
+  test "returns just the random string if no prefix is defined" do
+    output = Junk.junk(String)
+    assert String.at(output, 0) != "-"
+  end
+
   test "returns unique Integers" do
     assert Junk.junk(Integer) |> is_integer == true
     assert Junk.junk(Integer) != Junk.junk(Integer)
@@ -49,6 +61,12 @@ defmodule JunkTest do
     assert "1-result" = output
     output2 = Junk.junk(f, parameters: [2])
     assert "2-result" = output2
+  end
+
+  test "returns a preset value when a preset is not defined" do
+    output = Junk.junk(:firstname)
+    assert String.starts_with?(output, "firstname")
+    assert String.length(output) > String.length("firstname-")
   end
 
   test "returns a preset value when a preset is defined and used" do


### PR DESCRIPTION
Adds the ability to specify presets from the application config, using either the existing definition by type:
```elixir
config :ex_junk,
  phone: [Integer, [size: 10]]
```
Or defined by a function:
```elixir
config :ex_junk,
  ssn: &MyModule.Generates.ssn\1
```

